### PR TITLE
python 3, use __name__ instead of func_name

### DIFF
--- a/djangoseo/utils.py
+++ b/djangoseo/utils.py
@@ -37,7 +37,10 @@ def _pattern_resolve_to_name(pattern, path):
         elif hasattr(pattern, '_callback_str'):
             name = pattern._callback_str
         else:
-            name = "%s.%s" % (pattern.callback.__module__, pattern.callback.func_name)
+            try:
+                name = "%s.%s" % (pattern.callback.__module__, pattern.callback.__name__)
+            except AttributeError:
+                name = "%s.%s" % (pattern.callback.__module__, pattern.callback.func_name)
         return name
 
 


### PR DESCRIPTION
Due to renaming of function attribute **func_name** to ****name**** in Python 3 let's try to use **name** first.
