### PR TITLE
README - Fixed the doubled word "use"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ As you can see it is very flexible, but there is much more than this simple exam
 Installation
 ============
 
-The easiest way to install Django SEO is to use use ``pip``, if you have it::
+The easiest way to install Django SEO is to use ``pip``, if you have it::
 
     pip install django-seo
 


### PR DESCRIPTION
When I was browsing the readme file, I noticed a small mistake. The word "use" was doubled. I fixed it.